### PR TITLE
Bugfix for merging discs and polygons without a primary key

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -5,7 +5,7 @@
 name=Mosaic Builder
 qgisMinimumVersion=3.0
 description=Copy features from different layers and merge them together quickly and easily
-version=1.0
+version=1.0.1
 author=Dorset Council
 email=gis@dorsetcouncil.gov.uk
 
@@ -22,6 +22,9 @@ hasProcessingProvider=no
 changelog=
     1.0.0
     - Initial release
+
+    1.0.1
+    - Fixed issue preventing merge of features without primary key
 
 # Tags are comma separated with spaces allowed
 tags=python,vector,feature,feature extraction,polygon

--- a/mosaic_builder.py
+++ b/mosaic_builder.py
@@ -777,7 +777,13 @@ class MosaicBuilder:
                 featuresToAdd = []
                 featuresToRemove = []
                 for feature in selectLayer.selectedFeatures():
-                    fid = str(feature.id())  # This is the internal feature ID (primary key)
+                    provider = selectLayer.dataProvider()
+                    pkey_field = provider.pkAttributeIndexes()
+                    pkey_field_names = [selectLayer.fields()[i].name() for i in pkey_field]
+                    if len(pkey_field_names) > 0:
+                        fid = str([feature[name] for name in pkey_field_names]) # This is the defined primary key for the layer if known
+                    else:
+                        fid = str(feature.id())  # This is the internal feature ID (primary key)
                     if fid not in fidList:
                         fidList.append(str(fid))
                         if self.colourGrab:

--- a/mosaic_builder.py
+++ b/mosaic_builder.py
@@ -471,14 +471,14 @@ class MosaicBuilder:
                 if firstRun == True:
                     firstRun = False
                     geoms = feature.geometry()
-                    PrimaryKeyString = feature['Primary_Key']
+                    PrimaryKeyString = feature['Primary_Key'] if feature['Primary_Key'] is not None else 'NoKey'
                 else:
                     geom = feature.geometry()
                     if geom:
                         err = geom.validateGeometry()
                         if not err:
                             geoms = geoms.combine(geom)
-                            PKString = PrimaryKeyString + ', ' + feature['Primary_Key']
+                            PKString = PrimaryKeyString + ', ' + feature['Primary_Key'] if feature['Primary_Key'] is not None else 'NoKey'
                             if len(PKString) > 100:
                                 PrimaryKeyString = "Not recorded - too big"
                             else:

--- a/mosaic_builder.py
+++ b/mosaic_builder.py
@@ -21,6 +21,7 @@
  *                                                                         *
  ***************************************************************************/
 """
+from encodings.punycode import T
 from qgis.PyQt.QtCore import QSettings, QTranslator, QThread, QCoreApplication, QMetaType, QTimer, QUrl
 from qgis.PyQt.QtGui import QIcon, QDesktopServices
 from qgis.PyQt.QtWidgets import QApplication, QAction, QLabel, QMenu, QToolButton, QWidgetAction, QMainWindow, QSpinBox, QWidget, QHBoxLayout
@@ -777,13 +778,18 @@ class MosaicBuilder:
                 featuresToAdd = []
                 featuresToRemove = []
                 for feature in selectLayer.selectedFeatures():
-                    provider = selectLayer.dataProvider()
-                    pkey_field = provider.pkAttributeIndexes()
-                    pkey_field_names = [selectLayer.fields()[i].name() for i in pkey_field]
-                    if len(pkey_field_names) > 0:
-                        fid = str([feature[name] for name in pkey_field_names]) # This is the defined primary key for the layer if known
-                    else:
-                        fid = str(feature.id())  # This is the internal feature ID (primary key)
+                    try:
+                        provider = selectLayer.dataProvider()
+                        pkey_field = provider.pkAttributeIndexes()
+                        pkey_field_names = [selectLayer.fields()[i].name() for i in pkey_field]
+                        if len(pkey_field_names) > 0:
+                            fid = str([feature[name] for name in pkey_field_names]) # This is the defined primary key for the layer if known
+                        else:
+                            fid = str(feature.id())  # This is the internal feature ID (not primary key)
+                    except:
+                        # Something went wrong, just use the internal feature ID
+                        fid = str(feature.id()) 
+ 
                     if fid not in fidList:
                         fidList.append(str(fid))
                         if self.colourGrab:


### PR DESCRIPTION
The merge function was not written to handle null values in the primary key field. 

The disc tool creates features without a primary key but potentially input layers may also not have a primary key so this bug could have impacted on other scenarios as well.

I've added an if handler to put 'NoKey' as the value if a primary key is missing. This means that you can see the primary keys of features you merge. By design, the plugin will give up if you use too many input features to prevent a huge concatenated string but I tested it and was able to get a value of NoKey, 1, 2, 3, 4 which shows it now handles this correctly and removes duplicate values.   

Closes #25 