### PR TITLE
fix: correct self.areaTools to self.areaTool typo in mosaic_builder.py

### DIFF
--- a/mosaic_builder.py
+++ b/mosaic_builder.py
@@ -356,7 +356,7 @@ class MosaicBuilder:
 
         try:
             self.pointTool.canvasClicked.disconnect(self.selectByClick)
-            self.areaTools.canvasClicked.disconnect(self.selectByArea)
+            self.areaTool.canvasClicked.disconnect(self.selectByArea)
             self.discTool.canvasClicked.disconnect(self.bufferByClick)
             self.removeTool.canvasClicked.disconnect(self.removeByClick)
             self.radiusSpinbox.disconnect(self.setRadius)


### PR DESCRIPTION
## Summary
Corrects `self.areaTools` → `self.areaTool` typo in `mosaic_builder.py` line 359.

The attribute is defined as `self.areaTool` (singular) at line 81, but line 359 incorrectly referenced `self.areaTools` (plural) in the disconnect call.

Fixes #44

## Changes
- 1 file, 1 line changed
- Single commit, GH007 compliant